### PR TITLE
ci: push built derivations to cache even on build failure

### DIFF
--- a/.github/workflows/nix-ci.yaml
+++ b/.github/workflows/nix-ci.yaml
@@ -187,19 +187,34 @@ jobs:
           cache-signing-key: ${{ inputs.push-to-cache && secrets.cache-signing-key || '' }}
 
       - name: Build target
-        run: nix build ".#${{ matrix.attr }}"
+        # --keep-going: don't stop at the first failed dependency. Building as
+        # much of the closure as possible means the successfully built paths can
+        # still be pushed to the cache below, so a single broken derivation does
+        # not force everything else to be rebuilt on the next run.
+        run: nix build --keep-going ".#${{ matrix.attr }}"
 
-      - name: Resolve store path
+      - name: Resolve built store paths
         id: store-path
+        # always(): run even when the build step failed so we can still publish
+        # whatever was built. Skip the work entirely when not pushing.
+        if: ${{ always() && inputs.push-to-cache }}
         run: |
+          # The final output may be invalid (build failed), so resolve the whole
+          # derivation closure including outputs and keep only the paths that
+          # actually exist in the store. nix path-info --derivation instantiates
+          # the .drv without building it.
+          drv=$(nix path-info --derivation ".#${{ matrix.attr }}")
           {
             echo 'path<<EOF'
-            nix path-info ".#${{ matrix.attr }}"
+            nix-store --query --requisites --include-outputs "$drv" \
+              | while IFS= read -r p; do
+                  nix path-info "$p" >/dev/null 2>&1 && printf '%s\n' "$p"
+                done
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
       - name: Publish built path
-        if: ${{ inputs.push-to-cache }}
+        if: ${{ always() && inputs.push-to-cache }}
         uses: ./.znix-ci/.github/actions/push-nix-cache
         with:
           store-paths: ${{ steps.store-path.outputs.path }}

--- a/.github/workflows/nix-ci.yaml
+++ b/.github/workflows/nix-ci.yaml
@@ -203,13 +203,24 @@ jobs:
           # derivation closure including outputs and keep only the paths that
           # actually exist in the store. nix path-info --derivation instantiates
           # the .drv without building it.
-          drv=$(nix path-info --derivation ".#${{ matrix.attr }}")
+          drv=$(nix path-info --derivation ".#${{ matrix.attr }}" 2>/dev/null || true)
+          : > "$RUNNER_TEMP/candidates.txt" "$RUNNER_TEMP/invalid.txt"
+          if [[ -n "$drv" ]]; then
+            # Build-closure outputs minus the .drv files themselves (we publish
+            # built outputs, not derivations).
+            nix-store --query --requisites --include-outputs "$drv" \
+              | { grep -v '\.drv$' || true; } | sort -u > "$RUNNER_TEMP/candidates.txt"
+            # Keep only paths valid in the store. --print-invalid lists the
+            # missing ones in a single call, so a partial build still
+            # contributes its finished outputs without spawning a process per
+            # path.
+            xargs -r nix-store --check-validity --print-invalid \
+              < "$RUNNER_TEMP/candidates.txt" 2>/dev/null \
+              | sort -u > "$RUNNER_TEMP/invalid.txt"
+          fi
           {
             echo 'path<<EOF'
-            nix-store --query --requisites --include-outputs "$drv" \
-              | while IFS= read -r p; do
-                  nix path-info "$p" >/dev/null 2>&1 && printf '%s\n' "$p"
-                done
+            comm -23 "$RUNNER_TEMP/candidates.txt" "$RUNNER_TEMP/invalid.txt"
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/nix-update-pr.yaml
+++ b/.github/workflows/nix-update-pr.yaml
@@ -194,10 +194,15 @@ jobs:
           while IFS= read -r target; do
             [[ -z "$target" ]] && continue
             echo "::group::Building pre-update: $target"
-            nix build ".#${target}" --no-link
-            path=$(nix path-info ".#${target}")
-            old_paths["$target"]="$path"
-            echo "Pre-update store path: $path"
+            # --keep-going and tolerate failure so one broken target does not
+            # abort the loop; other targets still get built and diffed.
+            if nix build --keep-going ".#${target}" --no-link; then
+              path=$(nix path-info ".#${target}")
+              old_paths["$target"]="$path"
+              echo "Pre-update store path: $path"
+            else
+              echo "::warning::Pre-update build failed for ${target}; skipping its diff."
+            fi
             echo "::endgroup::"
           done < "$RUNNER_TEMP/diff-targets.txt"
 
@@ -232,7 +237,13 @@ jobs:
             fi
 
             echo "::group::Building post-update: $target"
-            nix build ".#${target}" --no-link
+            # --keep-going and tolerate failure so a single broken target does
+            # not abort the loop. Whatever built still gets pushed below.
+            if ! nix build --keep-going ".#${target}" --no-link; then
+              echo "::endgroup::"
+              echo "::warning::Post-update build failed for ${target}; skipping its diff."
+              continue
+            fi
             echo "::endgroup::"
 
             new_path=$(nix path-info ".#${target}")
@@ -263,16 +274,24 @@ jobs:
 
       - name: Collect post-update store paths
         id: post-paths
-        if: ${{ steps.check.outputs.has_changes == 'true' && env.CAN_DIFF == 'true' }}
+        # always(): collect even when a build step failed, so successfully built
+        # paths still get pushed and are not rebuilt on the next run.
+        if: ${{ always() && steps.check.outputs.has_changes == 'true' && env.CAN_DIFF == 'true' }}
         run: |
           : > "$RUNNER_TEMP/post-update-paths.txt"
           while IFS= read -r target; do
             [[ -z "$target" ]] && continue
-            path=$(nix path-info ".#${target}" 2>/dev/null || true)
-            if [[ -n "$path" ]]; then
-              printf '%s\n' "$path" >> "$RUNNER_TEMP/post-update-paths.txt"
-            fi
+            # Resolve the whole derivation closure (including outputs) and keep
+            # only paths that exist in the store, so partially built targets
+            # still contribute their finished dependencies.
+            drv=$(nix path-info --derivation ".#${target}" 2>/dev/null || true)
+            [[ -z "$drv" ]] && continue
+            nix-store --query --requisites --include-outputs "$drv" 2>/dev/null \
+              | while IFS= read -r p; do
+                  nix path-info "$p" >/dev/null 2>&1 && printf '%s\n' "$p"
+                done >> "$RUNNER_TEMP/post-update-paths.txt"
           done < "$RUNNER_TEMP/diff-targets.txt"
+          sort -u "$RUNNER_TEMP/post-update-paths.txt" -o "$RUNNER_TEMP/post-update-paths.txt"
           if [[ -s "$RUNNER_TEMP/post-update-paths.txt" ]]; then
             {
               echo 'paths<<EOF'
@@ -285,7 +304,7 @@ jobs:
           fi
 
       - name: Push post-update builds to cache
-        if: ${{ steps.post-paths.outputs.has_paths == 'true' && env.CAN_PUSH_CACHE == 'true' }}
+        if: ${{ always() && steps.post-paths.outputs.has_paths == 'true' && env.CAN_PUSH_CACHE == 'true' }}
         uses: ./.znix-ci/.github/actions/push-nix-cache
         with:
           store-paths: ${{ steps.post-paths.outputs.paths }}

--- a/.github/workflows/nix-update-pr.yaml
+++ b/.github/workflows/nix-update-pr.yaml
@@ -286,10 +286,19 @@ jobs:
             # still contribute their finished dependencies.
             drv=$(nix path-info --derivation ".#${target}" 2>/dev/null || true)
             [[ -z "$drv" ]] && continue
+            # Build-closure outputs minus the .drv files themselves (we publish
+            # built outputs, not derivations).
             nix-store --query --requisites --include-outputs "$drv" 2>/dev/null \
-              | while IFS= read -r p; do
-                  nix path-info "$p" >/dev/null 2>&1 && printf '%s\n' "$p"
-                done >> "$RUNNER_TEMP/post-update-paths.txt"
+              | { grep -v '\.drv$' || true; } | sort -u > "$RUNNER_TEMP/candidates.txt"
+            # Keep only paths valid in the store. --print-invalid lists the
+            # missing ones in a single call, so a partial build still
+            # contributes its finished outputs without spawning a process per
+            # path.
+            xargs -r nix-store --check-validity --print-invalid \
+              < "$RUNNER_TEMP/candidates.txt" 2>/dev/null \
+              | sort -u > "$RUNNER_TEMP/invalid.txt"
+            comm -23 "$RUNNER_TEMP/candidates.txt" "$RUNNER_TEMP/invalid.txt" \
+              >> "$RUNNER_TEMP/post-update-paths.txt"
           done < "$RUNNER_TEMP/diff-targets.txt"
           sort -u "$RUNNER_TEMP/post-update-paths.txt" -o "$RUNNER_TEMP/post-update-paths.txt"
           if [[ -s "$RUNNER_TEMP/post-update-paths.txt" ]]; then

--- a/.github/workflows/nix-update.yaml
+++ b/.github/workflows/nix-update.yaml
@@ -207,14 +207,26 @@ jobs:
         run: |
           # The final output may be invalid (build failed), so resolve the whole
           # derivation closure including outputs and keep only the paths that
-          # actually exist in the store.
-          drv=$(nix path-info --derivation ".#${{ matrix.attr }}")
+          # actually exist in the store. nix path-info --derivation instantiates
+          # the .drv without building it.
+          drv=$(nix path-info --derivation ".#${{ matrix.attr }}" 2>/dev/null || true)
+          : > "$RUNNER_TEMP/candidates.txt" "$RUNNER_TEMP/invalid.txt"
+          if [[ -n "$drv" ]]; then
+            # Build-closure outputs minus the .drv files themselves (we publish
+            # built outputs, not derivations).
+            nix-store --query --requisites --include-outputs "$drv" \
+              | { grep -v '\.drv$' || true; } | sort -u > "$RUNNER_TEMP/candidates.txt"
+            # Keep only paths valid in the store. --print-invalid lists the
+            # missing ones in a single call, so a partial build still
+            # contributes its finished outputs without spawning a process per
+            # path.
+            xargs -r nix-store --check-validity --print-invalid \
+              < "$RUNNER_TEMP/candidates.txt" 2>/dev/null \
+              | sort -u > "$RUNNER_TEMP/invalid.txt"
+          fi
           {
             echo 'path<<EOF'
-            nix-store --query --requisites --include-outputs "$drv" \
-              | while IFS= read -r p; do
-                  nix path-info "$p" >/dev/null 2>&1 && printf '%s\n' "$p"
-                done
+            comm -23 "$RUNNER_TEMP/candidates.txt" "$RUNNER_TEMP/invalid.txt"
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/nix-update.yaml
+++ b/.github/workflows/nix-update.yaml
@@ -195,18 +195,31 @@ jobs:
           cache-signing-key: ${{ secrets.cache-signing-key }}
 
       - name: Build target
-        run: nix build ".#${{ matrix.attr }}"
+        # --keep-going: don't stop at the first failed dependency so the rest of
+        # the closure still gets built and can be pushed to the cache below.
+        run: nix build --keep-going ".#${{ matrix.attr }}"
 
-      - name: Resolve store path
+      - name: Resolve built store paths
         id: store-path
+        # always(): publish whatever was built even when the build step failed,
+        # so a single broken derivation does not force a full rebuild next run.
+        if: ${{ always() }}
         run: |
+          # The final output may be invalid (build failed), so resolve the whole
+          # derivation closure including outputs and keep only the paths that
+          # actually exist in the store.
+          drv=$(nix path-info --derivation ".#${{ matrix.attr }}")
           {
             echo 'path<<EOF'
-            nix path-info ".#${{ matrix.attr }}"
+            nix-store --query --requisites --include-outputs "$drv" \
+              | while IFS= read -r p; do
+                  nix path-info "$p" >/dev/null 2>&1 && printf '%s\n' "$p"
+                done
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
       - name: Publish built path
+        if: ${{ always() }}
         uses: ./.znix-ci/.github/actions/push-nix-cache
         with:
           store-paths: ${{ steps.store-path.outputs.path }}


### PR DESCRIPTION
## Problem

Build matrix jobs build one target per job, but a target's closure contains many derivations. When `nix build` failed on a single dependency the whole job failed and **nothing** was pushed — so the already-built dependencies got rebuilt from scratch on every subsequent run.

## Change

Across `nix-ci.yaml`, `nix-update.yaml`, and the per-target build loops in `nix-update-pr.yaml`:

- Build with `nix build --keep-going` so a broken dependency does not stop the rest of the closure from building.
- Run resolve + push steps with `always()` so successfully built paths are signed and pushed even when the build step exited nonzero.
- Resolve the full derivation closure (`nix-store --query --requisites --include-outputs`) and keep only paths valid in the store, instead of relying on the final output that may not exist after a failed build.

## Test

This PR exists to exercise the CI on a real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)