### PR TITLE
fix(ci): stop FlakeHub Cache 401 noise

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -1,7 +1,7 @@
 name: Setup Nix
 description: >
-  Install Nix with optional signing key configuration. Installs Determinate Nix via determinate-nix-action (includes
-  FlakeHub Cache authentication) and optionally writes a signing key to disk.
+  Install Nix with optional signing key configuration. Installs Determinate Nix via determinate-nix-action and
+  optionally writes a signing key to disk.
 
 inputs:
   extra-substituters:
@@ -65,6 +65,18 @@ runs:
 
     - name: Install Nix
       uses: DeterminateSystems/determinate-nix-action@61cbfe2efc2d4e7a8a6d56967c3c1058e846c858 # v3.21.9
+      env:
+        # This account has no FlakeHub Cache entitlement, so the installer's
+        # FlakeHub login succeeds at OIDC and then fails at FlakeHub ("User is
+        # not authorized for this resource"), leaving cache.flakehub.com
+        # enrolled as a substituter that 401s on every narinfo lookup.
+        #
+        # The installer skips the login entirely when the OIDC endpoint env
+        # vars are absent, so blank them here. It then logs one info line
+        # claiming the workflow is misconfigured -- that is this comment, not a
+        # mistake. Nothing else in these workflows uses OIDC.
+        ACTIONS_ID_TOKEN_REQUEST_URL: ''
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: ''
       with:
         extra-conf: |
           download-buffer-size = 524288000

--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -72,9 +72,10 @@ runs:
         # enrolled as a substituter that 401s on every narinfo lookup.
         #
         # The installer skips the login entirely when the OIDC endpoint env
-        # vars are absent, so blank them here. It then logs one info line
-        # claiming the workflow is misconfigured -- that is this comment, not a
-        # mistake. Nothing else in these workflows uses OIDC.
+        # vars are unset or empty, so force-disable them here by setting blank
+        # values. It then logs one info line claiming the workflow is
+        # misconfigured -- that is this comment, not a mistake. Nothing else in
+        # these workflows uses OIDC.
         ACTIONS_ID_TOKEN_REQUEST_URL: ''
         ACTIONS_ID_TOKEN_REQUEST_TOKEN: ''
       with:

--- a/.github/workflows/nix-ci.yaml
+++ b/.github/workflows/nix-ci.yaml
@@ -109,7 +109,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   discover:

--- a/.github/workflows/nix-update-pr.yaml
+++ b/.github/workflows/nix-update-pr.yaml
@@ -96,7 +96,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   update-flake-pr:
@@ -104,7 +103,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
     env:
       HAS_APP_TOKEN: ${{ secrets.ci-app-id != '' && secrets.ci-app-private-key != '' }}
       CAN_DIFF: ${{ inputs.diff-targets != '' }}

--- a/.github/workflows/nix-update.yaml
+++ b/.github/workflows/nix-update.yaml
@@ -116,7 +116,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   update-flake:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,6 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   ci:

--- a/.github/workflows/update-pr.yaml
+++ b/.github/workflows/update-pr.yaml
@@ -12,7 +12,6 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
 
 jobs:
   pr:

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -17,7 +17,6 @@ concurrency:
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
   publish:

--- a/modules/home/shell/zsh/zshrc/tools/fzf.zsh
+++ b/modules/home/shell/zsh/zshrc/tools/fzf.zsh
@@ -6,8 +6,9 @@ if lib::check_commands fzf fd bat exa; then
   log::debug "Configuring fzf"
 
   export FZF_DEFAULT_OPTS='--multi --no-height --extended'
-  export FZF_DEFAULT_COMMAND='fd --no-ignore --strip-cwd-prefix --hidden --exclude .git --exclude node_modules --exclude "$GOPATH"'
+  export FZF_DEFAULT_COMMAND='fd --no-ignore --strip-cwd-prefix --hidden --exclude .git --exclude .direnv --exclude node_modules --exclude "$GOPATH"'
   export FZF_CTRL_T_COMMAND="${FZF_DEFAULT_COMMAND}"
+  export FZF_ALT_C_COMMAND="${FZF_DEFAULT_COMMAND} --type d"
   # TODO transform these commands to functions
   FZF_PREVIEW_MAX_LINES=200
   FZF_DIRECTORY_PREVIEW_CMD="exa -l --group-directories-first -T -L5 --color=always --color-scale {} | head -${FZF_PREVIEW_MAX_LINES}"


### PR DESCRIPTION
**What**: Skip the installer's FlakeHub login in CI and drop the now-unused `id-token: write` permission from all workflows.

**Why**: This account has no FlakeHub Cache entitlement. The login authenticates via OIDC, gets rejected (`"User is not authorized for this resource."`), and leaves `cache.flakehub.com` enrolled as a substituter that logs `error: unable to download 'https://edge.cache.flakehub.com/....narinfo': HTTP error 401` for every path. Builds still pass — Nix falls through to the next substituter — but the logs are unreadable.

**How**: `nix-installer-action` skips the login entirely when `ACTIONS_ID_TOKEN_REQUEST_URL`/`_TOKEN` are absent, so `setup-nix` blanks them on the install step. Nothing else consumes OIDC (the flake-update PR job uses a GitHub App token), so `id-token: write` goes too.

**Notes for reviewer**:
- Determinate Nix stays. CI keeps parity with `tuxedo`/`trv4250`, and the lazy-trees `drvPath` pre-instantiation in the check job is untouched.
- Side effect: one info line per job — `"FlakeHub is disabled because the workflow is misconfigured"`. Expected; the `setup-nix` comment explains it.
- `test.yaml` pins `nix-infra-ref: ${{ github.sha }}`, so this PR exercises its own `setup-nix`.
- Unrelated reds may persist (`mise` build, R2 upload 500). Out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cdPEvgNxXYPTZ6oKQH7qZ