### PR TITLE
Pin vendir sources to tags for per-source Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,15 @@
       "description": "Automerge all updates",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
+    },
+    {
+      "description": "Vendored sources land as committed trees in vendor/ and feed the agent harnesses — always review the diff",
+      "matchManagers": ["vendir"],
+      "automerge": false
     }
-  ]
+  ],
+  "vendir": {
+    "description": "Tags in vendir.yml are tracked per source, so a whole-lockfile refresh would only re-open the all-at-once PR",
+    "lockFileMaintenance": { "enabled": false }
+  }
 }

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,26 +2,26 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: 'Merge pull request #788 from mattpocock/grill-me-align...'
-      sha: 84fdeffd12f2ee307994d1eb6feb48173b6e0502
+      commitTitle: 'Merge pull request #782 from mattpocock/changeset-release/main...'
+      sha: 6acc160e4e0cd062dbbbd7a1b26ae92855edf07e
       tags:
-      - v1.2.3-2-g84fdeff
+      - v1.2.3
     path: .
   path: vendor/mattpocock-skills
 - contents:
   - git:
-      commitTitle: Update README.md with Skills.sh badge (#338)
-      sha: 309834233183478e6fd7800d26e1fbaa6210274e
+      commitTitle: 'chore: sync SKILL.md copies [skip ci]'
+      sha: fcf7663366c217dc8f334a11028de52ed950ceab
       tags:
-      - v1.10.0-5-g3098342
+      - v1.10.0
     path: .
   path: vendor/caveman
 - contents:
   - git:
-      commitTitle: 'feat: add Grok Build native skills adapter (revive #561) (#661)...'
-      sha: 2ed6c52c9d7e5e56942508591085fd45dea277d3
+      commitTitle: 'chore: release v4.9.0 (#703)...'
+      sha: 0a4dd63ad4541f4f655c4108a295916f3c1d8fda
       tags:
-      - v4.9.0-3-g2ed6c52
+      - v4.9.0
     path: .
   path: vendor/ponytail
 kind: LockConfig

--- a/vendir.yml
+++ b/vendir.yml
@@ -1,17 +1,20 @@
 apiVersion: vendir.k14s.io/v1alpha1
 kind: Config
+# Every source pins an upstream tag so Renovate's vendir manager can track it as
+# a real dependency and open one PR per source. A floating ref would leave
+# lockFileMaintenance as the only update path, which refreshes all sources at
+# once (one unreviewable PR). Bumps are never automerged — see renovate.json.
+# After editing a ref by hand, run `vendir sync` and commit the synced tree.
 directories:
   - path: vendor/mattpocock-skills
     contents:
       # Engineering + productivity skill sets from mattpocock/skills.
       # newRootPath strips the leading "skills/" so the tree lands as
       # vendor/mattpocock-skills/{engineering,productivity}/<skill>/.
-      # Update with `vendir sync` (re-resolves ref, rewrites vendir.lock.yml);
-      # the synced files are committed, so every update is a reviewable diff.
       - path: .
         git:
           url: https://github.com/mattpocock/skills
-          ref: origin/main
+          ref: v1.2.3
         includePaths:
           - skills/engineering/**
           - skills/productivity/**
@@ -25,12 +28,11 @@ directories:
       # Caveman skills + hooks/plugins from JuliusBrussee/caveman.
       # Consumed by modules/home/{claude,opencode}/caveman.nix via
       # inputs.self + "/vendor/caveman/...". Only the subtrees those modules
-      # read are vendored. Update with `vendir sync`; synced files are
-      # committed, so every update is a reviewable diff.
+      # read are vendored.
       - path: .
         git:
           url: https://github.com/JuliusBrussee/caveman
-          ref: origin/main
+          ref: v1.10.0
         includePaths: [ src/hooks/**, src/plugins/**, src/rules/**, skills/**, commands/** ]
         # Self-installers (`curl … | bash`, fetch hooks from GitHub at runtime)
         # stay out. Cavecrew is no longer deployed by any harness.
@@ -43,11 +45,10 @@ directories:
       # code minimisation instead of prose. The opencode plugin resolves its
       # siblings via realpath-relative requires (../../hooks, ../../skills,
       # ../command), so the whole subtree below must stay intact and co-located.
-      # Update with `vendir sync`; synced files are committed (reviewable diff).
       - path: .
         git:
           url: https://github.com/DietrichGebert/ponytail
-          ref: origin/main
+          ref: v4.9.0
         includePaths: [ hooks/**, skills/**, commands/**, .opencode/**, .cursor/** ]
         # Windows-only statusline and host hook-registration manifests are inert.
         excludePaths: [ hooks/*.ps1, hooks/claude-codex-hooks.json, hooks/copilot-hooks.json ]

--- a/vendor/ponytail/hooks/ponytail-runtime.js
+++ b/vendor/ponytail/hooks/ponytail-runtime.js
@@ -4,28 +4,13 @@ const os = require('os');
 const { getClaudeDir, getConfigDir } = require('./ponytail-config');
 
 const STATE_FILE = '.ponytail-active';
-
-// ponytail: VS Code Copilot never sets COPILOT_PLUGIN_DATA — it only injects
-// CLAUDE_PLUGIN_ROOT, pointed at an install path under .vscode/agent-plugins/
-// (#528). Without this fallback isCopilot was false, so ponytail assumed
-// native Claude Code and emitted the statusline nudge, which VS Code Copilot
-// doesn't read.
-function isVsCodeCopilotRoot(pluginRoot) {
-  if (!pluginRoot) return false;
-  return pluginRoot.split(/[\\/]+/).includes('agent-plugins') &&
-    pluginRoot.toLowerCase().includes('.vscode');
-}
-
-const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA) ||
-  isVsCodeCopilotRoot(process.env.CLAUDE_PLUGIN_ROOT);
+const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA);
 const isCodex = !isCopilot && Boolean(process.env.PLUGIN_DATA);
 const isQoder = !isCopilot && !isCodex && Boolean(process.env.QODER_SESSION_ID);
 
 let stateDir = getClaudeDir();
 if (isCodex) stateDir = process.env.PLUGIN_DATA;
-// COPILOT_PLUGIN_DATA is unset under VS Code Copilot, so fall back to
-// getClaudeDir() rather than building a path from undefined.
-if (isCopilot) stateDir = process.env.COPILOT_PLUGIN_DATA || getClaudeDir();
+if (isCopilot) stateDir = process.env.COPILOT_PLUGIN_DATA;
 if (isQoder) stateDir = path.join(os.homedir(), '.qoder');
 
 const statePath = path.join(stateDir, STATE_FILE);


### PR DESCRIPTION
**What**: Pin the three `vendir.yml` git sources to upstream tags instead of `origin/main`, and configure Renovate to never automerge vendir updates.

**Why**: `ref: origin/main` is invisible to Renovate as a version — the vendir manager extracts it as `currentValue: "origin/main"` against the `git-refs` datasource, but `git ls-remote` only returns `refs/heads/main` and `refs/tags/*`, never a remote-tracking name. With no per-dependency update possible, `lockFileMaintenance` (inherited from `config:best-practices` → `:maintainLockFilesWeekly`) was the only update path. Renovate implements it as a bare `vendir sync` with no directory scoping, and one `vendir.lock.yml` covers all three directories — hence #116, which refreshed every source at once and was not reviewable.

**How**: Each source pins a tag, so Renovate tracks three distinct dependencies and opens one PR per source. Tags are the `git describe` base tags of the previously locked commits, chosen to keep the vendored diff minimal rather than to land content updates:

| source | was | now |
|---|---|---|
| `mattpocock/skills` | `v1.2.3-2-g84fdeff` | `v1.2.3` |
| `JuliusBrussee/caveman` | `v1.10.0-5-g3098342` | `v1.10.0` |
| `DietrichGebert/ponytail` | `v4.9.0-3-g2ed6c52` | `v4.9.0` |

`renovate.json` gets a `matchManagers: ["vendir"]` rule with `automerge: false` (overriding the blanket minor/patch/pin/digest automerge, since it is last in `packageRules`), plus `vendir.lockFileMaintenance.enabled: false` so the weekly refresh can't re-open the all-at-once PR.

**Notes for reviewer**:

- Only one vendored file changes: `vendor/ponytail/hooks/ponytail-runtime.js` (+2/−17). It rolls back a VS Code Copilot detection fix, which is inert here — znix wires ponytail into Claude Code and OpenCode only, where `isCopilot` is `false` either way. mattpocock and caveman content is byte-identical at their base tags, since the commits they were ahead by touched nothing inside `includePaths`.
- Caveman has a tag at the exact previously-locked sha (`pre-caveman-2-2026-08-11`) which would have been a literal zero-diff pin, but it isn't semver, so the default versioning would filter it out of the release list and Renovate would never propose an upgrade from it.
- #116 should be closed once this lands. It is marked immortal and will keep being recreated until `lockFileMaintenance` is disabled on `main`.
- Live test of the new config is caveman `v1.10.0` → `v2.1.0`. mattpocock and ponytail are already at their newest tags, so they produce no PR until upstream tags again.

Checked: `renovate-config-validator --strict` passes; `nix fmt` reports 0 changed; `homeConfigurations."glashevich@trv4250".activationPackage` evaluates with all four vendored trees in its closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqKoQECCB4sDWkhG2PD3n3